### PR TITLE
Add unified server-side file utilities for consistent CompressedAugme…

### DIFF
--- a/frontend/app/api/chat/tool-handlers.server.ts
+++ b/frontend/app/api/chat/tool-handlers.server.ts
@@ -18,7 +18,7 @@ import { searchFilesInFolder } from '@/lib/search/file-search';
 import { executeQuery as execQuery } from '@/lib/api/execute-query.server';
 import { getNodeConnector } from '@/lib/connections';
 import { compressQueryResult } from '@/lib/api/file-state';
-import { dbFileToCompressedAugmented } from '@/lib/api/compress-augmented';
+import { readFilesServer } from '@/lib/api/file-state.server';
 
 // ============================================================================
 // Tool Implementations
@@ -161,16 +161,15 @@ registerTool('ExecuteQuery', async (args, user) => {
 /**
  * ReadFiles — server-side fallback.
  * Reads files directly from SQLite instead of the Redux store.
- * No Redux updates; the result is returned to the LLM only.
+ * Uses readFilesServer() for consistent behavior with client-side:
+ * - Includes references with parameter inheritance
+ * - Computes effective queryResultIds
  */
 registerToolFallback('ReadFiles', async (args, user) => {
   const { fileIds } = args as { fileIds: number[] };
-  const fileResults = await Promise.all(
-    fileIds.map(id => FilesAPI.loadFile(id, user).catch(() => null))
-  );
-  const validFiles = fileResults.filter((r): r is NonNullable<typeof r> => r != null).map(r => r.data);
+  const files = await readFilesServer(fileIds, user, { executeQueries: false });
   return {
-    content: { success: true, files: validFiles.map(f => dbFileToCompressedAugmented(f)) },
+    content: { success: true, files },
     details: { success: true },
   };
 });

--- a/frontend/app/api/jobs/test/route.ts
+++ b/frontend/app/api/jobs/test/route.ts
@@ -5,6 +5,7 @@ import { resolveHomeFolderSync } from '@/lib/mode/path-resolver';
 import { FilesAPI } from '@/lib/data/files.server';
 import { runQuery } from '@/lib/connections/run-query';
 import { createServerRunner } from '@/lib/tests/server';
+import { getAppStateServer } from '@/lib/api/file-state.server';
 import { EvalItem, BinaryAssertion, NumberAssertion, DatabaseWithSchema, QuestionContent, ConversationLogEntry, Test } from '@/lib/types';
 import { orchestratePendingTools } from '@/app/api/chat/orchestrator';
 import '@/app/api/chat/tool-handlers.server';
@@ -56,17 +57,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ passed: false, error: 'eval_item or test is required' } as EvalRunResponse, { status: 400 });
     }
 
-    // Build app_state from eval_item.app_state
+    // Build app_state from eval_item.app_state using unified server utilities
+    // This provides consistent CompressedAugmentedFile format with parameter inheritance
     let app_state: Record<string, unknown> | null = null;
     if (eval_item.app_state.type === 'file') {
-      const fileResult = await FilesAPI.loadFile(eval_item.app_state.file_id, user).catch(() => null);
-      if (fileResult) {
-        const file = fileResult.data;
-        app_state = {
-          type: 'file',
-          file: { id: file.id, name: file.name, path: file.path, type: file.type, content: file.content }
-        };
-      }
+      app_state = await getAppStateServer(eval_item.app_state.file_id, user, { executeQueries: true });
     }
 
     // Build the Python chat request

--- a/frontend/lib/api/file-state.server.ts
+++ b/frontend/lib/api/file-state.server.ts
@@ -84,6 +84,9 @@ function buildEffectiveReference(
   return {
     ...refFile,
     queryResultId: effectiveQueryResultId,
+    // Propagate effective params into content so compressFileState recomputes the hash
+    // from inherited values, not the question's standalone defaults.
+    content: { ...content, parameterValues: effectiveParamsDict },
   };
 }
 

--- a/frontend/lib/api/file-state.server.ts
+++ b/frontend/lib/api/file-state.server.ts
@@ -1,0 +1,233 @@
+/**
+ * Server-side File State Utilities
+ *
+ * Server-side equivalent of file-state.ts for loading files with references
+ * and query results. Used by tool fallbacks, MCP tools, test runners, and
+ * job handlers.
+ *
+ * Matches client-side behavior including:
+ * - Parameter inheritance for dashboards
+ * - Effective queryResultId computation
+ * - Optional query execution
+ */
+import 'server-only';
+import { FilesAPI } from '@/lib/data/files.server';
+import { runQuery } from '@/lib/connections/run-query';
+import { getQueryHash } from '@/lib/utils/query-hash';
+import {
+  compressAugmentedFile,
+  dbFileToFileState,
+} from '@/lib/api/compress-augmented';
+import type { EffectiveUser } from '@/lib/auth/auth-helpers';
+import type {
+  DbFile,
+  FileState,
+  AugmentedFile,
+  CompressedAugmentedFile,
+  QuestionContent,
+  QuestionParameter,
+  QueryResult,
+} from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Parameter Inheritance (mirrored from file-state.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract root params from a dashboard's parameterValues.
+ * For questions and other types, returns {} (no inheritance).
+ */
+function getRootParams(file: DbFile): Record<string, unknown> {
+  if (file.type === 'dashboard') {
+    return (file.content as { parameterValues?: Record<string, unknown> })?.parameterValues || {};
+  }
+  return {};
+}
+
+/**
+ * Merge inherited params with question's own params (inherited wins).
+ * Only includes params the question defines (no sibling pollution).
+ */
+function resolveEffectiveParams(
+  parameters: QuestionParameter[],
+  ownParamValues: Record<string, unknown>,
+  inheritedParams: Record<string, unknown>
+): Record<string, unknown> {
+  const dict: Record<string, unknown> = {};
+  for (const p of parameters) {
+    dict[p.name] = Object.prototype.hasOwnProperty.call(inheritedParams, p.name)
+      ? inheritedParams[p.name]
+      : (ownParamValues[p.name] ?? '');
+  }
+  return dict;
+}
+
+/**
+ * Build effective FileState with inherited params applied.
+ * Recomputes queryResultId based on effective parameter values.
+ */
+function buildEffectiveReference(
+  refFile: FileState,
+  inheritedParams: Record<string, unknown>
+): FileState {
+  if (refFile.type !== 'question' || !refFile.content) return refFile;
+
+  const content = refFile.content as QuestionContent;
+  const ownParamValues = content.parameterValues ?? {};
+  const effectiveParamsDict = content.parameters?.length
+    ? resolveEffectiveParams(content.parameters, ownParamValues, inheritedParams)
+    : {};
+  const effectiveQueryResultId = content.query && content.connection_name
+    ? getQueryHash(content.query, effectiveParamsDict, content.connection_name)
+    : refFile.queryResultId;
+
+  return {
+    ...refFile,
+    queryResultId: effectiveQueryResultId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Query Execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute queries for file and references with inherited params.
+ * Returns array of QueryResult with id field set.
+ */
+async function executeQueriesForFile(
+  file: DbFile,
+  references: DbFile[],
+  inheritedParams: Record<string, unknown>,
+  user: EffectiveUser
+): Promise<QueryResult[]> {
+  const results: QueryResult[] = [];
+
+  // Helper to execute query for a question
+  const execQuestion = async (q: DbFile): Promise<void> => {
+    if (q.type !== 'question') return;
+    const content = q.content as QuestionContent;
+    if (!content.query || !content.connection_name) return;
+
+    const ownParamValues = content.parameterValues ?? {};
+    const params = content.parameters?.length
+      ? resolveEffectiveParams(content.parameters, ownParamValues, inheritedParams)
+      : ownParamValues;
+
+    // Convert to the format runQuery expects
+    const paramRecord: Record<string, string | number> = {};
+    for (const [k, v] of Object.entries(params)) {
+      if (typeof v === 'string' || typeof v === 'number') {
+        paramRecord[k] = v;
+      } else if (v != null) {
+        paramRecord[k] = String(v);
+      }
+    }
+
+    const id = getQueryHash(content.query, params, content.connection_name);
+
+    try {
+      const result = await runQuery(content.connection_name, content.query, paramRecord, user);
+      results.push({ ...result, id });
+    } catch (err) {
+      results.push({
+        columns: [],
+        types: [],
+        rows: [],
+        id,
+        error: err instanceof Error ? err.message : 'Query failed',
+      } as QueryResult & { error: string });
+    }
+  };
+
+  // Execute for main file if it's a question
+  await execQuestion(file);
+
+  // Execute for all referenced questions in parallel
+  await Promise.all(references.map(ref => execQuestion(ref)));
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ReadFilesServerOptions {
+  /** Execute queries for question files. Default: false */
+  executeQueries?: boolean;
+}
+
+/**
+ * Load files by ID with references, optionally executing queries.
+ * Server-side equivalent of client's readFiles() + selectAugmentedFiles().
+ *
+ * @param fileIds - Array of file IDs to load
+ * @param user - Effective user for permissions and connection access
+ * @param options - Options including whether to execute queries
+ * @returns Array of CompressedAugmentedFile matching client format
+ */
+export async function readFilesServer(
+  fileIds: number[],
+  user: EffectiveUser,
+  options: ReadFilesServerOptions = {}
+): Promise<CompressedAugmentedFile[]> {
+  const { executeQueries = false } = options;
+
+  const results: CompressedAugmentedFile[] = [];
+
+  for (const fileId of fileIds) {
+    try {
+      const fileResult = await FilesAPI.loadFile(fileId, user);
+      if (!fileResult.data) continue;
+
+      const file = fileResult.data;
+      const refs = fileResult.metadata?.references ?? [];
+      const inheritedParams = getRootParams(file);
+
+      // Convert to FileState with effective params applied to references
+      const fileState = dbFileToFileState(file);
+      const refFileStates = refs.map(ref =>
+        buildEffectiveReference(dbFileToFileState(ref), inheritedParams)
+      );
+
+      // Execute queries if requested
+      let queryResults: QueryResult[] = [];
+      if (executeQueries) {
+        queryResults = await executeQueriesForFile(file, refs, inheritedParams, user);
+      }
+
+      // Build and compress
+      const augmented: AugmentedFile = {
+        fileState,
+        references: refFileStates,
+        queryResults,
+      };
+
+      results.push(compressAugmentedFile(augmented));
+    } catch {
+      // Skip files that fail to load (permission denied, not found, etc.)
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Build app state for a file.
+ * Server-side equivalent of selectAppState() for file contexts.
+ *
+ * @param fileId - File ID to load
+ * @param user - Effective user for permissions
+ * @param options - Options including whether to execute queries
+ * @returns AppState object or null if file not found
+ */
+export async function getAppStateServer(
+  fileId: number,
+  user: EffectiveUser,
+  options: ReadFilesServerOptions = {}
+): Promise<{ type: 'file'; state: CompressedAugmentedFile } | null> {
+  const files = await readFilesServer([fileId], user, options);
+  if (files.length === 0) return null;
+  return { type: 'file', state: files[0] };
+}

--- a/frontend/lib/api/file-state.ts
+++ b/frontend/lib/api/file-state.ts
@@ -106,7 +106,9 @@ function buildEffectiveReference(refFile: FileState, inheritedParams: Record<str
   return {
     ...stripped,
     queryResultId: effectiveQueryResultId,
-    content: { ...content },
+    // Propagate effective params into content so compressFileState recomputes the hash
+    // from inherited values, not the question's standalone defaults.
+    content: { ...content, parameterValues: effectiveParamsDict },
   };
 }
 

--- a/frontend/lib/jobs/handlers/report-handler.ts
+++ b/frontend/lib/jobs/handlers/report-handler.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import { FilesAPI } from '@/lib/data/files.server';
 import { runChatOrchestration } from '@/lib/chat/run-orchestration';
 import { resolveBaseUrl } from '@/lib/jobs/job-utils';
-import { dbFileToCompressedAugmented } from '@/lib/api/compress-augmented';
+import { getAppStateServer } from '@/lib/api/file-state.server';
 import type { ReportContent, ReportOutput, ReportRunContent, JobHandlerResult, JobRunnerInput } from '@/lib/types';
 import type { JobHandler } from '../job-registry';
 
@@ -19,18 +19,18 @@ export const reportJobHandler: JobHandler = {
     // Load reference files from DB and build CompressedAugmentedFile for each.
     // The Python AnalystAgent expects app_state: { type: 'file', state: CompressedAugmentedFile }
     // — the same shape ChatInterface builds client-side via compressAugmentedFile().
-    // dbFileToCompressedAugmented handles the DbFile → CompressedAugmentedFile pipeline,
-    // including passing the file's own references (e.g. questions inside a dashboard).
+    // getAppStateServer handles the full pipeline including:
+    // - Parameter inheritance for dashboards
+    // - Query execution with inherited params
     const enrichedReferences = await Promise.all(
       (report.references || []).map(async (ref) => {
+        // Load file for metadata (name, path, connection_id)
         const refResult = await FilesAPI.loadFile(ref.reference.id, user);
         const refFile = refResult.data;
-        const refFileRefs = (refResult.metadata?.references ?? []);
         const connectionId = (refFile?.content as any)?.connection_name;
 
-        const appState = refFile
-          ? { type: 'file' as const, state: dbFileToCompressedAugmented(refFile, refFileRefs) }
-          : null;
+        // Build app state with query execution enabled for reports
+        const appState = await getAppStateServer(ref.reference.id, user, { executeQueries: true });
 
         return {
           ...ref,

--- a/frontend/lib/mcp/server.ts
+++ b/frontend/lib/mcp/server.ts
@@ -21,7 +21,7 @@ import { executeQuery as execQuery } from '@/lib/api/execute-query.server';
 import { getNodeConnector } from '@/lib/connections';
 import { compressQueryResult } from '@/lib/api/file-state';
 import { searchFilesInFolder } from '@/lib/search/file-search';
-import { dbFileToCompressedAugmented } from '@/lib/api/compress-augmented';
+import { readFilesServer } from '@/lib/api/file-state.server';
 
 export type McpToolCallResult = { content: Array<{ type: 'text'; text: string }> };
 export type OnToolCall = (tool: string, args: Record<string, unknown>, result: McpToolCallResult) => void;
@@ -220,15 +220,13 @@ export function createMcpServer(user: EffectiveUser, onToolCall?: OnToolCall): M
       },
     },
     async ({ fileIds }: { fileIds: number[] }) => {
-      const fileResults = await Promise.all(
-        fileIds.map(id => FilesAPI.loadFile(id, user).catch(() => null))
-      );
-      const validFiles = fileResults
-        .filter((r): r is NonNullable<typeof r> => r != null)
-        .map(r => dbFileToCompressedAugmented(r.data));
+      // Use readFilesServer for consistent behavior with client-side:
+      // - Includes references with parameter inheritance
+      // - Computes effective queryResultIds
+      const files = await readFilesServer(fileIds, user, { executeQueries: false });
 
       const result: McpToolCallResult = {
-        content: [{ type: 'text' as const, text: JSON.stringify({ success: true, files: validFiles }) }],
+        content: [{ type: 'text' as const, text: JSON.stringify({ success: true, files }) }],
       };
       onToolCall?.('ReadFiles', { fileIds }, result);
       return result;

--- a/frontend/lib/tests/server.ts
+++ b/frontend/lib/tests/server.ts
@@ -16,7 +16,7 @@ import { resolveHomeFolderSync } from '@/lib/mode/path-resolver';
 import { pythonBackendFetch } from '@/lib/api/python-backend-client';
 import { orchestratePendingTools } from '@/app/api/chat/orchestrator';
 import '@/app/api/chat/tool-handlers.server';
-import { dbFileToCompressedAugmented } from '@/lib/api/compress-augmented';
+import { getAppStateServer } from '@/lib/api/file-state.server';
 import type { EffectiveUser } from '@/lib/auth/auth-helpers';
 import type { PythonChatResponse, CompletedToolCallPayload, CompletedToolCallFromPython } from '@/lib/chat-orchestration';
 import type {
@@ -139,14 +139,11 @@ async function executeLLMTest(
 ): Promise<TestRunResult> {
   const subject = test.subject as Extract<typeof test.subject, { type: 'llm' }>;
 
-  // Build app_state for the Python agent
+  // Build app_state for the Python agent using unified server utilities
+  // executeQueries: true so the agent has query results available
   let app_state: Record<string, unknown> | null = null;
   if (subject.context.type === 'file') {
-    const fileResult = await FilesAPI.loadFile(subject.context.file_id, user);
-    if (fileResult.data) {
-      const refs = fileResult.metadata?.references ?? [];
-      app_state = { type: 'file', state: dbFileToCompressedAugmented(fileResult.data, refs) };
-    }
+    app_state = await getAppStateServer(subject.context.file_id, user, { executeQueries: true });
   }
 
   const resolvedHomeFolder = resolveHomeFolderSync(user.mode, user.home_folder || '');

--- a/frontend/store/__tests__/file-state-server-parity.test.ts
+++ b/frontend/store/__tests__/file-state-server-parity.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Client-Server File State Parity Tests
+ *
+ * Verifies that for the same file in the DB, the client pipeline and the
+ * server pipeline produce identical CompressedAugmentedFile output.
+ *
+ * Parity invariant (for clean, unedited files):
+ *   compressAugmentedFile(selectAugmentedFiles(state, [id])[0])
+ *     ===
+ *   (await readFilesServer([id], user))[0]
+ *
+ * Both paths ultimately call compressAugmentedFile(dbFileToFileState(file)),
+ * so with persistableChanges={} and metadataChanges={} the outputs must match.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import filesReducer from '../filesSlice';
+import queryResultsReducer from '../queryResultsSlice';
+import authReducer from '../authSlice';
+import { getTestDbPath, initTestDatabase, cleanupTestDatabase } from './test-utils';
+import { DocumentDB } from '@/lib/database/documents-db';
+import type { QuestionContent, DocumentContent, UserRole } from '@/lib/types';
+import type { Mode } from '@/lib/mode/mode-types';
+import type { EffectiveUser } from '@/lib/auth/auth-helpers';
+import type { AugmentedFile, CompressedAugmentedFile } from '@/lib/types';
+import { readFiles, selectAugmentedFiles, compressAugmentedFile } from '@/lib/api/file-state';
+import { readFilesServer, getAppStateServer } from '@/lib/api/file-state.server';
+import { POST as batchPostHandler } from '@/app/api/files/batch/route';
+import { GET as fileGetHandler } from '@/app/api/files/[id]/route';
+import { setupMockFetch } from '@/test/harness/mock-fetch';
+import { NextRequest } from 'next/server';
+
+// Mock db-config to use test database
+jest.mock('@/lib/database/db-config', () => {
+  const path = require('path');
+  const dbPath = path.join(process.cwd(), 'data', 'test_server_parity.db');
+  return {
+    DB_PATH: dbPath,
+    DB_DIR: path.join(process.cwd(), 'data'),
+    getDbType: () => 'sqlite'
+  };
+});
+
+// Mock the store import so file-state.ts uses the test store
+let testStore: any;
+jest.mock('@/store/store', () => ({
+  get store() {
+    return testStore;
+  },
+  getStore: () => testStore
+}));
+
+// Mock python-backend-client for executeQueries tests
+jest.mock('@/lib/api/python-backend-client', () => ({
+  pythonBackendFetch: jest.fn(async (url: string, init?: any) => {
+    if (url.includes('/api/execute-query')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          columns: ['month', 'total'],
+          types: ['TEXT', 'INTEGER'],
+          rows: [
+            { month: 'Jan', total: 1000 },
+            { month: 'Feb', total: 1500 },
+          ]
+        })
+      } as Response;
+    }
+    throw new Error(`Unmocked pythonBackendFetch call to ${url}`);
+  })
+}));
+
+describe('Client-Server File State Parity', () => {
+  const dbPath = getTestDbPath('server_parity');
+  let store: ReturnType<typeof configureStore>;
+  let questionId: number;
+  let dashboardId: number;
+  let paramQuestionId: number;
+  let paramDashboardId: number;
+
+  // Route client API calls to real Next.js handlers (no Python backend needed for parity tests)
+  setupMockFetch({
+    getPythonPort: () => 0,
+    additionalInterceptors: [
+      async (urlStr, init) => {
+        const fullUrl = urlStr.startsWith('http') ? urlStr : `http://localhost:3000${urlStr}`;
+
+        if (urlStr.includes('/api/files/batch') && !urlStr.includes('batch-save')) {
+          const req = new NextRequest('http://localhost:3000/api/files/batch', {
+            method: init?.method || 'POST',
+            body: init?.body,
+            headers: { ...init?.headers, 'x-company-id': '1', 'x-user-id': '1' }
+          });
+          const res = await batchPostHandler(req);
+          return { ok: res.status === 200, status: res.status, json: async () => res.json() } as Response;
+        }
+
+        if (urlStr.match(/\/api\/files\/\d+(\?|$)/) && (!init?.method || init?.method === 'GET')) {
+          const fileId = urlStr.match(/\/api\/files\/(\d+)/)?.[1];
+          const req = new NextRequest(fullUrl, {
+            method: 'GET',
+            headers: { 'x-company-id': '1', 'x-user-id': '1' }
+          });
+          const res = await fileGetHandler(req, { params: Promise.resolve({ id: fileId! }) });
+          return { ok: res.status === 200, status: res.status, json: async () => res.json() } as Response;
+        }
+
+        return null;
+      }
+    ],
+  });
+
+  const testUser: EffectiveUser = {
+    userId: 1,
+    email: 'test@example.com',
+    name: 'Test User',
+    role: 'admin',
+    home_folder: '/org',
+    companyId: 1,
+    companyName: 'test-company',
+    mode: 'org',
+  };
+
+  beforeAll(async () => {
+    await initTestDatabase(dbPath);
+    const companyId = 1;
+
+    // Simple question (no params)
+    questionId = await DocumentDB.create(
+      'Sales Query',
+      '/org/sales-query',
+      'question',
+      {
+        description: 'Total sales by month',
+        query: 'SELECT month, SUM(total) as total FROM sales GROUP BY month',
+        connection_name: 'test_db',
+        parameters: [],
+        vizSettings: { type: 'table', xCols: [], yCols: [] }
+      } as QuestionContent,
+      [],
+      companyId
+    );
+
+    // Dashboard referencing the simple question
+    dashboardId = await DocumentDB.create(
+      'Sales Dashboard',
+      '/org/sales-dashboard',
+      'dashboard',
+      {
+        description: 'Sales overview',
+        assets: [{ type: 'question', id: questionId }],
+        layout: {},
+        parameterValues: {}
+      } as DocumentContent,
+      [questionId],
+      companyId
+    );
+
+    // Question with parameters (for inheritance tests)
+    paramQuestionId = await DocumentDB.create(
+      'Limited Sales Query',
+      '/org/limited-sales-query',
+      'question',
+      {
+        description: 'Sales with limit param',
+        query: 'SELECT month, total FROM sales LIMIT :limit',
+        connection_name: 'test_db',
+        parameters: [{ name: 'limit', type: 'number', value: '5' }],
+        parameterValues: { limit: '5' },
+        vizSettings: { type: 'table', xCols: [], yCols: [] }
+      } as unknown as QuestionContent,
+      [],
+      companyId
+    );
+
+    // Dashboard with inherited parameterValues overriding question default
+    paramDashboardId = await DocumentDB.create(
+      'Param Sales Dashboard',
+      '/org/param-sales-dashboard',
+      'dashboard',
+      {
+        description: 'Sales with param override',
+        assets: [{ type: 'question', id: paramQuestionId }],
+        layout: {},
+        parameterValues: { limit: '10' }
+      } as unknown as DocumentContent,
+      [paramQuestionId],
+      companyId
+    );
+
+    store = configureStore({
+      reducer: {
+        files: filesReducer,
+        queryResults: queryResultsReducer,
+        auth: authReducer
+      },
+      preloadedState: {
+        auth: {
+          user: {
+            id: 1,
+            email: 'test@example.com',
+            name: 'Test User',
+            role: 'admin' as UserRole,
+            companyId: 1,
+            companyName: 'test-company',
+            home_folder: '/org',
+            mode: 'org' as Mode
+          },
+          loading: false
+        }
+      }
+    });
+
+    testStore = store;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase(dbPath);
+  });
+
+  // Helper: load file via client Redux pipeline and compress it
+  async function getClientCompressed(id: number): Promise<CompressedAugmentedFile> {
+    await readFiles([id]);
+    const augmented: AugmentedFile[] = selectAugmentedFiles(store.getState() as any, [id]);
+    expect(augmented).toHaveLength(1);
+    return compressAugmentedFile(augmented[0]);
+  }
+
+  // ============================================================================
+  // Test 1: Simple question parity
+  // ============================================================================
+
+  it('readFilesServer matches compressed client output for a simple question', async () => {
+    const client = await getClientCompressed(questionId);
+    const server = await readFilesServer([questionId], testUser);
+
+    expect(server).toHaveLength(1);
+    expect(server[0].fileState.id).toBe(questionId);
+    expect(server[0].fileState.type).toBe('question');
+    expect(server[0].fileState.isDirty).toBe(false);
+
+    // Core parity assertion: same shape, same content
+    expect(server[0]).toEqual(client);
+  });
+
+  // ============================================================================
+  // Test 2: Dashboard with references parity
+  // ============================================================================
+
+  it('readFilesServer matches compressed client output for a dashboard with references', async () => {
+    // Load question into Redux first (dashboard references it)
+    await readFiles([questionId]);
+    const client = await getClientCompressed(dashboardId);
+    const server = await readFilesServer([dashboardId], testUser);
+
+    expect(server).toHaveLength(1);
+    expect(server[0].fileState.id).toBe(dashboardId);
+    expect(server[0].references).toHaveLength(1);
+    expect(server[0].references[0].id).toBe(questionId);
+
+    // Core parity assertion
+    expect(server[0]).toEqual(client);
+  });
+
+  // ============================================================================
+  // Test 3: Parameter inheritance — queryResultId matches
+  // ============================================================================
+
+  it('parameter inheritance produces identical queryResultId on client and server', async () => {
+    // Load question first so it's in Redux when we load the dashboard
+    await readFiles([paramQuestionId]);
+    const client = await getClientCompressed(paramDashboardId);
+    const server = await readFilesServer([paramDashboardId], testUser);
+
+    // Both should have the reference with an effective queryResultId
+    expect(server[0].references).toHaveLength(1);
+    expect(server[0].references[0].queryResultId).toBeDefined();
+    expect(client.references[0].queryResultId).toBeDefined();
+
+    // The inherited param (limit=10 from dashboard) should produce the same hash on both sides
+    expect(server[0].references[0].queryResultId).toEqual(client.references[0].queryResultId);
+
+    // Full parity
+    expect(server[0]).toEqual(client);
+  });
+
+  // ============================================================================
+  // Test 4: getAppStateServer wraps readFilesServer correctly
+  // ============================================================================
+
+  it('getAppStateServer wraps readFilesServer with correct type envelope', async () => {
+    const result = await getAppStateServer(questionId, testUser);
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('file');
+
+    // Should contain the same data as readFilesServer([questionId])[0]
+    const direct = await readFilesServer([questionId], testUser);
+    expect(result!.state).toEqual(direct[0]);
+  });
+
+  it('getAppStateServer returns null for a non-existent file', async () => {
+    const result = await getAppStateServer(999999, testUser);
+    expect(result).toBeNull();
+  });
+
+  // ============================================================================
+  // Test 5: executeQueries: true populates queryResults
+  // ============================================================================
+
+  it('executeQueries: true returns populated queryResults with id matching queryResultId', async () => {
+    const server = await readFilesServer([questionId], testUser, { executeQueries: true });
+
+    expect(server).toHaveLength(1);
+    expect(server[0].fileState.queryResultId).toBeDefined();
+
+    // Query should have been executed and result stored
+    expect(server[0].queryResults).toHaveLength(1);
+    const qr = server[0].queryResults[0];
+
+    // id on the query result must match the queryResultId on the fileState
+    expect(qr.id).toEqual(server[0].fileState.queryResultId);
+
+    // Result should be serialised as a GFM markdown table
+    expect(qr.columns).toEqual(['month', 'total']);
+    expect(qr.data).toContain('| month | total |');
+    expect(qr.data).toContain('| Jan | 1000 |');
+    expect(qr.totalRows).toBe(2);
+    expect(qr.shownRows).toBe(2);
+    expect(qr.truncated).toBe(false);
+  });
+
+  it('executeQueries: false leaves queryResults empty', async () => {
+    const server = await readFilesServer([questionId], testUser, { executeQueries: false });
+
+    expect(server).toHaveLength(1);
+    expect(server[0].queryResults).toHaveLength(0);
+  });
+});

--- a/frontend/store/__tests__/file-state-server-parity.test.ts
+++ b/frontend/store/__tests__/file-state-server-parity.test.ts
@@ -11,6 +11,21 @@
  *
  * Both paths ultimately call compressAugmentedFile(dbFileToFileState(file)),
  * so with persistableChanges={} and metadataChanges={} the outputs must match.
+ *
+ * Tests are structured to address three key invariants:
+ *
+ *   Invariant 1 — Parameter inheritance is correct on BOTH paths:
+ *     The queryResultId for a dashboard reference reflects the dashboard's
+ *     parameterValues (limit=10), NOT the question's own default (limit=5).
+ *
+ *   Invariant 2 — executeQueries executes through references:
+ *     readFilesServer([dashboardId], user, { executeQueries: true }) executes
+ *     the referenced question's query (not just the dashboard) and the returned
+ *     queryResult.id matches the reference's inherited queryResultId.
+ *
+ *   Invariant 3 — Server is independent of client Redux state:
+ *     When the client has unsaved edits (isDirty=true), the server still returns
+ *     the saved DB state. After publishFile, both converge to the same output.
  */
 
 import { configureStore } from '@reduxjs/toolkit';
@@ -20,17 +35,26 @@ import authReducer from '../authSlice';
 import { getTestDbPath, initTestDatabase, cleanupTestDatabase } from './test-utils';
 import { DocumentDB } from '@/lib/database/documents-db';
 import type { QuestionContent, DocumentContent, UserRole } from '@/lib/types';
+import type { CompressedAugmentedFile } from '@/lib/types';
 import type { Mode } from '@/lib/mode/mode-types';
 import type { EffectiveUser } from '@/lib/auth/auth-helpers';
-import type { AugmentedFile, CompressedAugmentedFile } from '@/lib/types';
-import { readFiles, selectAugmentedFiles, compressAugmentedFile } from '@/lib/api/file-state';
+import {
+  readFiles,
+  selectAugmentedFiles,
+  compressAugmentedFile,
+  editFileStr,
+  publishFile,
+} from '@/lib/api/file-state';
 import { readFilesServer, getAppStateServer } from '@/lib/api/file-state.server';
+import { getQueryHash } from '@/lib/utils/query-hash';
 import { POST as batchPostHandler } from '@/app/api/files/batch/route';
-import { GET as fileGetHandler } from '@/app/api/files/[id]/route';
+import { GET as fileGetHandler, PATCH as filePatchHandler } from '@/app/api/files/[id]/route';
 import { setupMockFetch } from '@/test/harness/mock-fetch';
 import { NextRequest } from 'next/server';
 
-// Mock db-config to use test database
+// ---------------------------------------------------------------------------
+// Mock: test database
+// ---------------------------------------------------------------------------
 jest.mock('@/lib/database/db-config', () => {
   const path = require('path');
   const dbPath = path.join(process.cwd(), 'data', 'test_server_parity.db');
@@ -41,16 +65,18 @@ jest.mock('@/lib/database/db-config', () => {
   };
 });
 
-// Mock the store import so file-state.ts uses the test store
+// ---------------------------------------------------------------------------
+// Mock: Redux store (file-state.ts reads from this via getStore())
+// ---------------------------------------------------------------------------
 let testStore: any;
 jest.mock('@/store/store', () => ({
-  get store() {
-    return testStore;
-  },
-  getStore: () => testStore
+  get store() { return testStore; },
+  getStore: () => testStore,
 }));
 
-// Mock python-backend-client for executeQueries tests
+// ---------------------------------------------------------------------------
+// Mock: Python backend (for executeQueries tests)
+// ---------------------------------------------------------------------------
 jest.mock('@/lib/api/python-backend-client', () => ({
   pythonBackendFetch: jest.fn(async (url: string, init?: any) => {
     if (url.includes('/api/execute-query')) {
@@ -71,36 +97,58 @@ jest.mock('@/lib/api/python-backend-client', () => ({
   })
 }));
 
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
 describe('Client-Server File State Parity', () => {
   const dbPath = getTestDbPath('server_parity');
   let store: ReturnType<typeof configureStore>;
-  let questionId: number;
-  let dashboardId: number;
-  let paramQuestionId: number;
-  let paramDashboardId: number;
 
-  // Route client API calls to real Next.js handlers (no Python backend needed for parity tests)
+  // File IDs created in beforeAll
+  let questionId: number;       // plain question, no params
+  let dashboardId: number;      // dashboard referencing questionId
+  let paramQuestionId: number;  // question with :limit param (own default: limit=5)
+  let paramDashboardId: number; // dashboard overriding limit=10
+
+  // ---------------------------------------------------------------------------
+  // Route client HTTP calls to real Next.js route handlers so both the client
+  // path (HTTP → handler → DB) and the server path (direct → DB) hit the same DB.
+  // ---------------------------------------------------------------------------
   setupMockFetch({
     getPythonPort: () => 0,
     additionalInterceptors: [
       async (urlStr, init) => {
         const fullUrl = urlStr.startsWith('http') ? urlStr : `http://localhost:3000${urlStr}`;
 
+        // POST /api/files/batch — used by readFiles / loadFiles
         if (urlStr.includes('/api/files/batch') && !urlStr.includes('batch-save')) {
           const req = new NextRequest('http://localhost:3000/api/files/batch', {
             method: init?.method || 'POST',
             body: init?.body,
-            headers: { ...init?.headers, 'x-company-id': '1', 'x-user-id': '1' }
+            headers: { ...init?.headers, 'x-company-id': '1', 'x-user-id': '1' },
           });
           const res = await batchPostHandler(req);
           return { ok: res.status === 200, status: res.status, json: async () => res.json() } as Response;
         }
 
+        // PATCH /api/files/:id — used by publishFile
+        if (urlStr.match(/\/api\/files\/\d+(\?|$)/) && (init?.method === 'PATCH' || init?.method === 'PUT')) {
+          const fileId = urlStr.match(/\/api\/files\/(\d+)/)?.[1];
+          const req = new NextRequest(fullUrl, {
+            method: 'PATCH',
+            body: init?.body,
+            headers: { ...init?.headers, 'x-company-id': '1', 'x-user-id': '1' },
+          });
+          const res = await filePatchHandler(req, { params: Promise.resolve({ id: fileId! }) });
+          return { ok: res.status === 200, status: res.status, json: async () => res.json() } as Response;
+        }
+
+        // GET /api/files/:id — individual file fetch
         if (urlStr.match(/\/api\/files\/\d+(\?|$)/) && (!init?.method || init?.method === 'GET')) {
           const fileId = urlStr.match(/\/api\/files\/(\d+)/)?.[1];
           const req = new NextRequest(fullUrl, {
             method: 'GET',
-            headers: { 'x-company-id': '1', 'x-user-id': '1' }
+            headers: { 'x-company-id': '1', 'x-user-id': '1' },
           });
           const res = await fileGetHandler(req, { params: Promise.resolve({ id: fileId! }) });
           return { ok: res.status === 200, status: res.status, json: async () => res.json() } as Response;
@@ -122,11 +170,14 @@ describe('Client-Server File State Parity', () => {
     mode: 'org',
   };
 
+  // ---------------------------------------------------------------------------
+  // Setup
+  // ---------------------------------------------------------------------------
   beforeAll(async () => {
     await initTestDatabase(dbPath);
     const companyId = 1;
 
-    // Simple question (no params)
+    // Simple question — no params
     questionId = await DocumentDB.create(
       'Sales Query',
       '/org/sales-query',
@@ -136,13 +187,13 @@ describe('Client-Server File State Parity', () => {
         query: 'SELECT month, SUM(total) as total FROM sales GROUP BY month',
         connection_name: 'test_db',
         parameters: [],
-        vizSettings: { type: 'table', xCols: [], yCols: [] }
+        vizSettings: { type: 'table', xCols: [], yCols: [] },
       } as QuestionContent,
       [],
       companyId
     );
 
-    // Dashboard referencing the simple question
+    // Dashboard referencing the simple question (no param override)
     dashboardId = await DocumentDB.create(
       'Sales Dashboard',
       '/org/sales-dashboard',
@@ -151,13 +202,13 @@ describe('Client-Server File State Parity', () => {
         description: 'Sales overview',
         assets: [{ type: 'question', id: questionId }],
         layout: {},
-        parameterValues: {}
+        parameterValues: {},
       } as DocumentContent,
       [questionId],
       companyId
     );
 
-    // Question with parameters (for inheritance tests)
+    // Question with :limit param — own default limit=5
     paramQuestionId = await DocumentDB.create(
       'Limited Sales Query',
       '/org/limited-sales-query',
@@ -168,13 +219,13 @@ describe('Client-Server File State Parity', () => {
         connection_name: 'test_db',
         parameters: [{ name: 'limit', type: 'number', value: '5' }],
         parameterValues: { limit: '5' },
-        vizSettings: { type: 'table', xCols: [], yCols: [] }
+        vizSettings: { type: 'table', xCols: [], yCols: [] },
       } as unknown as QuestionContent,
       [],
       companyId
     );
 
-    // Dashboard with inherited parameterValues overriding question default
+    // Dashboard overriding limit=10 (overrides question's default of 5)
     paramDashboardId = await DocumentDB.create(
       'Param Sales Dashboard',
       '/org/param-sales-dashboard',
@@ -183,7 +234,7 @@ describe('Client-Server File State Parity', () => {
         description: 'Sales with param override',
         assets: [{ type: 'question', id: paramQuestionId }],
         layout: {},
-        parameterValues: { limit: '10' }
+        parameterValues: { limit: '10' },
       } as unknown as DocumentContent,
       [paramQuestionId],
       companyId
@@ -193,7 +244,7 @@ describe('Client-Server File State Parity', () => {
       reducer: {
         files: filesReducer,
         queryResults: queryResultsReducer,
-        auth: authReducer
+        auth: authReducer,
       },
       preloadedState: {
         auth: {
@@ -205,11 +256,11 @@ describe('Client-Server File State Parity', () => {
             companyId: 1,
             companyName: 'test-company',
             home_folder: '/org',
-            mode: 'org' as Mode
+            mode: 'org' as Mode,
           },
-          loading: false
-        }
-      }
+          loading: false,
+        },
+      },
     });
 
     testStore = store;
@@ -219,122 +270,202 @@ describe('Client-Server File State Parity', () => {
     await cleanupTestDatabase(dbPath);
   });
 
-  // Helper: load file via client Redux pipeline and compress it
+  // ---------------------------------------------------------------------------
+  // Helper: load file through the client Redux pipeline and compress it.
+  // This is the exact same path that the LLM tool ReadFiles / selectAppState uses.
+  // ---------------------------------------------------------------------------
   async function getClientCompressed(id: number): Promise<CompressedAugmentedFile> {
     await readFiles([id]);
-    const augmented: AugmentedFile[] = selectAugmentedFiles(store.getState() as any, [id]);
+    const augmented = selectAugmentedFiles(store.getState() as any, [id]);
     expect(augmented).toHaveLength(1);
     return compressAugmentedFile(augmented[0]);
   }
 
   // ============================================================================
-  // Test 1: Simple question parity
+  // Basic parity: simple question, clean state
   // ============================================================================
 
-  it('readFilesServer matches compressed client output for a simple question', async () => {
+  it('simple question: client and server produce identical output', async () => {
     const client = await getClientCompressed(questionId);
     const server = await readFilesServer([questionId], testUser);
 
     expect(server).toHaveLength(1);
-    expect(server[0].fileState.id).toBe(questionId);
-    expect(server[0].fileState.type).toBe('question');
-    expect(server[0].fileState.isDirty).toBe(false);
-
-    // Core parity assertion: same shape, same content
     expect(server[0]).toEqual(client);
   });
 
   // ============================================================================
-  // Test 2: Dashboard with references parity
+  // Basic parity: dashboard with references, clean state
   // ============================================================================
 
-  it('readFilesServer matches compressed client output for a dashboard with references', async () => {
-    // Load question into Redux first (dashboard references it)
-    await readFiles([questionId]);
+  it('dashboard with reference: client and server produce identical output', async () => {
     const client = await getClientCompressed(dashboardId);
     const server = await readFilesServer([dashboardId], testUser);
 
     expect(server).toHaveLength(1);
-    expect(server[0].fileState.id).toBe(dashboardId);
     expect(server[0].references).toHaveLength(1);
-    expect(server[0].references[0].id).toBe(questionId);
-
-    // Core parity assertion
     expect(server[0]).toEqual(client);
   });
 
   // ============================================================================
-  // Test 3: Parameter inheritance — queryResultId matches
+  // Invariant 1: parameter inheritance is correct on BOTH paths
+  //
+  // The paramDashboard has parameterValues: { limit: '10' }.
+  // The paramQuestion has its own default parameterValues: { limit: '5' }.
+  // Both client and server must compute queryResultId using the INHERITED limit=10,
+  // not the question's own default of 5. We prove this by checking against the
+  // known hashes for each value.
   // ============================================================================
 
-  it('parameter inheritance produces identical queryResultId on client and server', async () => {
-    // Load question first so it's in Redux when we load the dashboard
-    await readFiles([paramQuestionId]);
+  it('parameter inheritance: queryResultId uses dashboard override, not question default, on both paths', async () => {
+    const inheritedHash = getQueryHash(
+      'SELECT month, total FROM sales LIMIT :limit',
+      { limit: '10' },
+      'test_db'
+    );
+    const standaloneHash = getQueryHash(
+      'SELECT month, total FROM sales LIMIT :limit',
+      { limit: '5' },
+      'test_db'
+    );
+    // These should actually differ — if they're equal the test setup is wrong
+    expect(inheritedHash).not.toEqual(standaloneHash);
+
     const client = await getClientCompressed(paramDashboardId);
     const server = await readFilesServer([paramDashboardId], testUser);
 
-    // Both should have the reference with an effective queryResultId
-    expect(server[0].references).toHaveLength(1);
-    expect(server[0].references[0].queryResultId).toBeDefined();
-    expect(client.references[0].queryResultId).toBeDefined();
-
-    // The inherited param (limit=10 from dashboard) should produce the same hash on both sides
-    expect(server[0].references[0].queryResultId).toEqual(client.references[0].queryResultId);
-
-    // Full parity
+    // Both paths must agree (parity)
     expect(server[0]).toEqual(client);
+
+    // AND both must specifically use the inherited value (not the question default)
+    expect(client.references[0].queryResultId).toEqual(inheritedHash);
+    expect(server[0].references[0].queryResultId).toEqual(inheritedHash);
+    expect(client.references[0].queryResultId).not.toEqual(standaloneHash);
   });
 
   // ============================================================================
-  // Test 4: getAppStateServer wraps readFilesServer correctly
+  // getAppStateServer wrapper
   // ============================================================================
 
-  it('getAppStateServer wraps readFilesServer with correct type envelope', async () => {
+  it('getAppStateServer: wraps readFilesServer with { type: "file", state } envelope', async () => {
     const result = await getAppStateServer(questionId, testUser);
 
     expect(result).not.toBeNull();
     expect(result!.type).toBe('file');
 
-    // Should contain the same data as readFilesServer([questionId])[0]
     const direct = await readFilesServer([questionId], testUser);
     expect(result!.state).toEqual(direct[0]);
   });
 
-  it('getAppStateServer returns null for a non-existent file', async () => {
+  it('getAppStateServer: returns null for non-existent file', async () => {
     const result = await getAppStateServer(999999, testUser);
     expect(result).toBeNull();
   });
 
   // ============================================================================
-  // Test 5: executeQueries: true populates queryResults
+  // Full E2E: Invariants 2 + 3 together
+  //
+  // This test walks through the complete lifecycle:
+  //
+  //   1. Baseline parity (client == server, clean state)
+  //   2. Edit on client → client becomes dirty
+  //   3. Server reads DB → still sees old state (Invariant 3: independence)
+  //   4. Server executes queries through dashboard reference (Invariant 2)
+  //      - queryResults[0].id matches reference's inherited queryResultId
+  //      - inherited queryResultId uses limit=10, not limit=5 (Invariant 1 again)
+  //   5. Publish → DB updated
+  //   6. Parity restored: client and server agree on the new saved state
   // ============================================================================
 
-  it('executeQueries: true returns populated queryResults with id matching queryResultId', async () => {
-    const server = await readFilesServer([questionId], testUser, { executeQueries: true });
+  it('full E2E: dirty client diverges from server; executeQueries via reference; publish restores parity', async () => {
+    // ------------------------------------------------------------------
+    // 1. Baseline: load everything fresh, verify client == server
+    // ------------------------------------------------------------------
+    const baseline = await readFilesServer([paramDashboardId], testUser);
+    const baselineClient = await getClientCompressed(paramDashboardId);
+    expect(baseline[0]).toEqual(baselineClient);
+    expect(baselineClient.references[0].isDirty).toBe(false);
 
-    expect(server).toHaveLength(1);
-    expect(server[0].fileState.queryResultId).toBeDefined();
+    // ------------------------------------------------------------------
+    // 2. Edit the question on the client — makes Redux dirty, DB unchanged
+    // ------------------------------------------------------------------
+    const editResult = await editFileStr({
+      fileId: paramQuestionId,
+      oldMatch: '"description":"Sales with limit param"',
+      newMatch: '"description":"Sales with limit param (edited)"',
+    });
+    expect(editResult.success).toBe(true);
 
-    // Query should have been executed and result stored
-    expect(server[0].queryResults).toHaveLength(1);
-    const qr = server[0].queryResults[0];
+    // Client now shows the edit and marks the reference dirty
+    const dirtyClient = await getClientCompressed(paramDashboardId);
+    expect(dirtyClient.references[0].isDirty).toBe(true);
+    expect((dirtyClient.references[0].content as any).description).toBe(
+      'Sales with limit param (edited)'
+    );
 
-    // id on the query result must match the queryResultId on the fileState
-    expect(qr.id).toEqual(server[0].fileState.queryResultId);
+    // ------------------------------------------------------------------
+    // 3. Invariant 3: server is independent — reads DB, sees old state
+    // ------------------------------------------------------------------
+    const serverAfterEdit = await readFilesServer([paramDashboardId], testUser);
 
-    // Result should be serialised as a GFM markdown table
+    expect(serverAfterEdit[0].references[0].isDirty).toBe(false);
+    expect((serverAfterEdit[0].references[0].content as any).description).toBe(
+      'Sales with limit param'   // original value — not the client edit
+    );
+
+    // Confirm client and server now DIFFER (diverged as expected)
+    expect(serverAfterEdit[0]).not.toEqual(dirtyClient);
+
+    // ------------------------------------------------------------------
+    // 4. Invariant 2: executeQueries fires through dashboard references
+    //    and Invariant 1: the executed hash uses inherited params (limit=10)
+    // ------------------------------------------------------------------
+    const inheritedHash = getQueryHash(
+      'SELECT month, total FROM sales LIMIT :limit',
+      { limit: '10' },
+      'test_db'
+    );
+
+    const serverWithQueries = await readFilesServer(
+      [paramDashboardId],
+      testUser,
+      { executeQueries: true }
+    );
+
+    // The dashboard itself is not a question — only the reference has a query result
+    expect(serverWithQueries[0].queryResults).toHaveLength(1);
+
+    const qr = serverWithQueries[0].queryResults[0];
+    // id must match the reference's effective (inherited) queryResultId
+    expect(qr.id).toEqual(inheritedHash);
+    expect(qr.id).toEqual(serverWithQueries[0].references[0].queryResultId);
+
+    // Result is serialised as a GFM markdown table
     expect(qr.columns).toEqual(['month', 'total']);
     expect(qr.data).toContain('| month | total |');
     expect(qr.data).toContain('| Jan | 1000 |');
     expect(qr.totalRows).toBe(2);
-    expect(qr.shownRows).toBe(2);
     expect(qr.truncated).toBe(false);
-  });
 
-  it('executeQueries: false leaves queryResults empty', async () => {
-    const server = await readFilesServer([questionId], testUser, { executeQueries: false });
+    // ------------------------------------------------------------------
+    // 5. Publish: save the client edit to DB
+    // ------------------------------------------------------------------
+    await publishFile({ fileId: paramQuestionId });
 
-    expect(server).toHaveLength(1);
-    expect(server[0].queryResults).toHaveLength(0);
+    // Client is clean again after publish
+    const postPublishClient = await getClientCompressed(paramDashboardId);
+    expect(postPublishClient.references[0].isDirty).toBe(false);
+    expect((postPublishClient.references[0].content as any).description).toBe(
+      'Sales with limit param (edited)'
+    );
+
+    // ------------------------------------------------------------------
+    // 6. Parity restored: server re-reads DB and matches client
+    // ------------------------------------------------------------------
+    const postPublishServer = await readFilesServer([paramDashboardId], testUser);
+
+    expect((postPublishServer[0].references[0].content as any).description).toBe(
+      'Sales with limit param (edited)'
+    );
+    expect(postPublishServer[0]).toEqual(postPublishClient);
   });
 });


### PR DESCRIPTION
…ntedFile output

This creates file-state.server.ts with readFilesServer() and getAppStateServer() that produce identical CompressedAugmentedFile format as client-side code:
- Includes references with parameter inheritance (dashboard params cascade to questions)
- Computes effective queryResultIds based on inherited params
- Optionally executes queries with inherited parameters

Updates all server-side consumers:
- ReadFiles tool fallback (tool-handlers.server.ts)
- MCP ReadFiles tool (mcp/server.ts)
- Test runner (tests/server.ts)
- Report handler (report-handler.ts)
- Legacy EvalItem path (jobs/test/route.ts) - fixes wrong shape {file:...} -> {state:...}

https://claude.ai/code/session_01B1PstYnv2YXrq8Um3iYLT4