### PR TITLE
Relax when config has empty name

### DIFF
--- a/frontend/lib/branding/whitelabel.ts
+++ b/frontend/lib/branding/whitelabel.ts
@@ -127,11 +127,15 @@ export function mergeConfig(
   return {
     branding: {
       ...defaults.branding,
-      ...(overrides.branding || {})
+      ...Object.fromEntries(
+        Object.entries(overrides.branding || {}).filter(([, v]) => v !== '')
+      ),
     },
     links: {
       ...defaults.links,
-      ...(overrides.links || {})
+      ...Object.fromEntries(
+        Object.entries(overrides.links || {}).filter(([, v]) => v !== '')
+      ),
     },
     messaging: overrides.messaging ?? defaults.messaging,
     channels: overrides.channels ?? defaults.channels,

--- a/frontend/lib/validation/config-validators.ts
+++ b/frontend/lib/validation/config-validators.ts
@@ -71,12 +71,10 @@ export function validateOrgConfig(content: unknown): content is Partial<OrgConfi
 
     for (const field of validFields) {
       if (branding[field] !== undefined) {
-        if (typeof branding[field] !== 'string' || branding[field].trim() === '') return false;
+        if (typeof branding[field] !== 'string') return false;
       }
     }
-    for (const field of Object.keys(branding)) {
-      if (!validFields.includes(field)) return false;
-    }
+    // Allow unknown branding fields — don't reject the entire config for extra keys
   }
 
   if (config.links !== undefined) {
@@ -87,12 +85,10 @@ export function validateOrgConfig(content: unknown): content is Partial<OrgConfi
 
     for (const field of validFields) {
       if (links[field] !== undefined) {
-        if (typeof links[field] !== 'string' || links[field].trim() === '') return false;
+        if (typeof links[field] !== 'string') return false;
       }
     }
-    for (const field of Object.keys(links)) {
-      if (!validFields.includes(field)) return false;
-    }
+    // Allow unknown links fields
   }
 
   if (config.messaging !== undefined) {


### PR DESCRIPTION
- I'm not sure how, but i entered into a state where the displayName is empty in config.
- This violates the config check, so the config is not used
- Which means setupWizard is also not `complete`
- Reroutes me to hello-world ALL THE TIME