### PR TITLE
Stop stripping pi-ai patch in runtime stage; verify it survives

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -80,8 +80,23 @@ COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/lib ./lib
 COPY --from=builder /app/tsconfig.json ./tsconfig.json
 
-# Install tsx for running TypeScript scripts
-RUN npm install --ignore-scripts tsx
+# Install tsx GLOBALLY for running TypeScript scripts.
+#
+# We must NOT install into /app/node_modules — that would reconcile against the
+# package-lock.json shipped in /app/.next/standalone and reinstall every package
+# (including @mariozechner/pi-ai) from the npm tarball, overwriting the
+# patched anthropic.js produced by postinstall in the builder stage and
+# shipping an unpatched pi-ai at runtime (silently breaking image-URL
+# attachments + web search). `--global` installs to /usr/local and leaves
+# /app/node_modules untouched.
+RUN npm install --global --ignore-scripts tsx
+
+# Defense in depth: verify the patched pi-ai survived to the runtime image.
+# Mirrors the builder-stage guard so any future change that strips patches
+# (e.g. another stray `npm install` in /app) fails the build instead of
+# silently shipping broken images.
+RUN grep -q "MX PATCH" /app/node_modules/@mariozechner/pi-ai/dist/providers/anthropic.js \
+    || (echo "ERROR: pi-ai patch missing from runtime image — something in the runner stage stripped it" && exit 1)
 
 # Create data directories (docker-compose volumes mount over these; standalone runs use them directly)
 RUN mkdir -p /app/data/pglite /app/data/analytics


### PR DESCRIPTION
## Background

Companion fix to #419 (the builder-stage guard for pi-ai patches).

After #419 merged, the new build's guard (`RUN grep -q "MX PATCH" …` at the end of the builder stage) **passed cleanly** — proving the patch was being applied correctly in the builder. Yet the published `:latest` image *still* shipped unpatched pi-ai:

```
$ docker run --rm ghcr.io/minusxai/minusx-frontend-canary:latest \
    grep -c "MX PATCH" /app/node_modules/@mariozechner/pi-ai/dist/providers/anthropic.js
0
```

So the bug was always downstream of `npm ci` — the runtime stage was silently undoing patch-package's work.

## Root cause

The runner stage has:

```dockerfile
COPY --from=builder /app/.next/standalone ./
# … other COPY --from=builder lines …
RUN npm install --ignore-scripts tsx
```

Next.js standalone ships its own `package.json` + `package-lock.json` in `.next/standalone/`. When `npm install --ignore-scripts tsx` runs to add tsx, npm reconciles the entire lockfile against `/app/node_modules` and **reinstalls every package — including `@mariozechner/pi-ai` — from its npm tarball**. That overwrites the patched `anthropic.js` (which the builder-stage postinstall produced) with the upstream copy. `--ignore-scripts` then suppresses postinstall, so patch-package never re-runs in the runtime stage to re-apply the patch.

Net: builder stage = patched ✅, runtime image = unpatched ❌.

## Fix

Install tsx **globally** (`--global`), landing it in `/usr/local/lib/node_modules/tsx` + `/usr/local/bin/tsx`. The application's `/app/node_modules` is never touched, the patched pi-ai is preserved end-to-end. `npx tsx` and bare `tsx` both still resolve via the global bin.

Also add a **runtime-stage** grep guard mirroring the one in the builder. If any future RUN line strips patches in the runner, build fails loudly with a clear error.

## Test plan

After merge, the next `publish.yml` run should:
1. Pass the builder-stage guard (already does)
2. Pass the new runtime-stage guard (new — verifies the patched file survives to runtime)
3. Produce a runtime image where `/app/node_modules/@mariozechner/pi-ai/dist/providers/anthropic.js` has 9 `MX PATCH` markers

After that, image-URL attachments + Anthropic web search should start working on the OSS canary deploy. Same fix is in `minusxai/minusx-prod` for the proprietary canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)